### PR TITLE
Improve handling credits reset timestamp in Imgur responses

### DIFF
--- a/src/uploaders/imguranonuploader.cpp
+++ b/src/uploaders/imguranonuploader.cpp
@@ -77,7 +77,9 @@ void ImgurAnonUploader::updateCredits()
 	credits.appLimit = json.data[APP_LIMIT_CSTR].toInt();
 	credits.appRemaining = json.data[APP_REMAINING_CSTR].toInt();
 
-	ui->userReset->setDateTime(QDateTime::fromTime_t(json.data[USER_RESET_CSTR].toInt()));
+	auto creditsResetInSecs = json.data[USER_RESET_CSTR].toInt();
+
+	ui->userReset->setDateTime(QDateTime::fromTime_t(creditsResetInSecs));
 	ui->userCredits->setText(QString("%1 / %2").arg(credits.userRemaining).arg(credits.userLimit));
 	ui->appCredits->setText(QString("%1 / %2").arg(credits.appRemaining).arg(credits.appLimit));
 

--- a/src/uploaders/imguranonuploader.cpp
+++ b/src/uploaders/imguranonuploader.cpp
@@ -77,7 +77,7 @@ void ImgurAnonUploader::updateCredits()
 	credits.appLimit = json.data[APP_LIMIT_CSTR].toInt();
 	credits.appRemaining = json.data[APP_REMAINING_CSTR].toInt();
 
-	auto creditsResetInSecs = json.data[USER_RESET_CSTR].toInt();
+	qint64 creditsResetInSecs = json.data[USER_RESET_CSTR].toLongLong();
 
 	ui->userReset->setDateTime(QDateTime::fromSecsSinceEpoch(creditsResetInSecs));
 	ui->userCredits->setText(QString("%1 / %2").arg(credits.userRemaining).arg(credits.userLimit));

--- a/src/uploaders/imguranonuploader.cpp
+++ b/src/uploaders/imguranonuploader.cpp
@@ -79,7 +79,7 @@ void ImgurAnonUploader::updateCredits()
 
 	auto creditsResetInSecs = json.data[USER_RESET_CSTR].toInt();
 
-	ui->userReset->setDateTime(QDateTime::fromTime_t(creditsResetInSecs));
+	ui->userReset->setDateTime(QDateTime::fromSecsSinceEpoch(creditsResetInSecs));
 	ui->userCredits->setText(QString("%1 / %2").arg(credits.userRemaining).arg(credits.userLimit));
 	ui->appCredits->setText(QString("%1 / %2").arg(credits.appRemaining).arg(credits.appLimit));
 


### PR DESCRIPTION
- Replace obsolete function.
- Use `qint64` for timestamps.
- Get rid of some compiler warning.