### PR TITLE
QVariant maps in JSON responses parsing

### DIFF
--- a/src/uploaders/imguranonuploader.cpp
+++ b/src/uploaders/imguranonuploader.cpp
@@ -56,7 +56,7 @@ QString ImgurAnonUploader::uploadImage(QString filePath, QIODevice *image)
 	ImgurResponse json(tr);
 	error = json.mergedError;
 	image->close();
-	return json.success ? json.data["link"] : "";
+	return json.success ? json.data["link"].toString() : "";
 }
 
 QString ImgurAnonUploader::tosUrl() const

--- a/src/uploaders/imgurloginuploader.cpp
+++ b/src/uploaders/imgurloginuploader.cpp
@@ -56,7 +56,7 @@ bool ImgurLoginUploader::init(int imageNumber)
 	ImgurResponse json(transaction);
 	error = json.mergedError;
 	if (transaction.success)
-		albumId = json.data["id"];
+		albumId = json.data["id"].toString();
 	return transaction.success;
 }
 

--- a/src/uploaders/imgurresponse.cpp
+++ b/src/uploaders/imgurresponse.cpp
@@ -55,12 +55,12 @@ void ImgurResponse::parseResponse(const NetworkTransaction &tr)
 		QJsonObject::const_iterator it;
 
 		for(it = jsonData.constBegin(); it != jsonData.constEnd(); it++) {
-			data.insert(it.key(), it.value().toVariant().toString());
+			data.insert(it.key(), it.value().toVariant());
 		}
 	}
 
 	if (data.contains("error") && error.isEmpty())
-		error = data.take("error");
+		error = data.take("error").toString();
 
 	QStringList errors;
 	if (!tr.error.isEmpty())
@@ -68,7 +68,7 @@ void ImgurResponse::parseResponse(const NetworkTransaction &tr)
 	if (!error.isEmpty())
 		errors << error;
 	if (data.contains("message"))
-		errors << data["message"];
+		errors << data["message"].toString();
 
 	mergedError = errors.join("\n");
 }

--- a/src/uploaders/imgurresponse.cpp
+++ b/src/uploaders/imgurresponse.cpp
@@ -51,12 +51,7 @@ void ImgurResponse::parseResponse(const NetworkTransaction &tr)
 	}
 
 	if (jsonRoot.contains("data")) {
-		QJsonObject jsonData = jsonRoot["data"].toObject();
-		QJsonObject::const_iterator it;
-
-		for(it = jsonData.constBegin(); it != jsonData.constEnd(); it++) {
-			data.insert(it.key(), it.value().toVariant());
-		}
+		data = jsonRoot["data"].toObject().toVariantMap();
 	}
 
 	if (data.contains("error") && error.isEmpty())

--- a/src/uploaders/imgurresponse.h
+++ b/src/uploaders/imgurresponse.h
@@ -2,6 +2,7 @@
 
 #include <QString>
 #include <QMap>
+#include <QVariant>
 
 class NetworkTransaction;
 
@@ -31,8 +32,7 @@ public:
 	void debug() const;
 
 	/// @brief Key-value pairs found in "data" object of server's response.
-	/// @todo Consider making it <QString, QVariant> to avoid type conversions.
-	QMap<QString, QString> data;
+	QMap<QString, QVariant> data;
 	bool success;
 	int status;
 	QString error;


### PR DESCRIPTION
For representing JSON response fields, use `QMap<QString, QVariant>` instead of `QMap<QString, QString>`, as the latter performs unnecessary and possibly problematic data conversions.