### PR TITLE
Replace some obsolete Qt API calls with supported ones

### DIFF
--- a/src/downloaders/tilesdownloader.cpp
+++ b/src/downloaders/tilesdownloader.cpp
@@ -132,7 +132,7 @@ QNetworkRequest TilesDownloader::createRequest(int zoom, int x, int y, QPoint be
 		url.replace(varNames[i], QString::number(vars[i]));
 
 	QNetworkRequest request(url);
-	request.setRawHeader("User-Agent", (qApp->applicationName() + " " + qApp->applicationVersion()).toAscii());
+	request.setRawHeader("User-Agent", (qApp->applicationName() + " " + qApp->applicationVersion()).toLatin1());
 	urlToTilePos[request.url()] = (QPoint(x, y) - begin) * tileSize;
 	return request;
 }

--- a/src/myexif/exifimageheader.cpp
+++ b/src/myexif/exifimageheader.cpp
@@ -235,7 +235,7 @@ void ExifImageHeader::setGpsPosition(QPointF position)
 
 qreal ExifImageHeader::dmsToReal(const ExifValue &dms, const ExifValue &ref)
 {
-	char c = ref.toString().toAscii()[0];
+	char c = ref.toString().toLatin1()[0];
 	const QVector<ExifURational> vector = dms.toRationalVector();
 	return (vector[0].toReal() + vector[1].toReal() / 60 + vector[2].toReal() / 3600) * ((c == 'S' || c == 'W') ? -1 : 1);
 }

--- a/src/myexif/exifvalue.cpp
+++ b/src/myexif/exifvalue.cpp
@@ -316,7 +316,7 @@ void ExifValue::writeValue(QDataStream &stream, QDataStream &valueStream) const
 
 void ExifValue::writeString(QDataStream &stream, QDataStream &valueStream) const
 {
-	QByteArray data = toString().toAscii() + QByteArray("\0", 1);
+	QByteArray data = toString().toLatin1() + QByteArray("\0", 1);
 	QVector<qint8> vector(data.size());
 	memcpy(vector.data(), data.constData(), data.size());
 	writeVector(stream, valueStream, vector);

--- a/src/settings/settingsmanager.cpp
+++ b/src/settings/settingsmanager.cpp
@@ -46,7 +46,7 @@ void SettingsManager::AbstractInput::connect(QObject *receiver, const char *memb
 	string.remove(QRegExp("^[0-9]+"));
 	string.remove(QRegExp("\\(\\)$"));
 
-	listeners.insert(qMakePair(QPointer<QObject>(receiver), string.toAscii()));
+	listeners.insert(qMakePair(QPointer<QObject>(receiver), string.toLatin1()));
 }
 
 void SettingsManager::AbstractInput::changedRemotely() const
@@ -57,7 +57,7 @@ void SettingsManager::AbstractInput::changedRemotely() const
 
 QByteArray SettingsManager::AbstractInput::encode(QString pass) const
 {
-	return qCompress(pass.toAscii()) ^ pasKey;
+	return qCompress(pass.toLatin1()) ^ pasKey;
 }
 
 QString SettingsManager::AbstractInput::decode(QByteArray pass) const

--- a/src/uploaders/abstractuploader.cpp
+++ b/src/uploaders/abstractuploader.cpp
@@ -78,11 +78,11 @@ QString AbstractUploader::removeAccents(QString diacritical)
 	{
 		if (c.category() > QChar::Mark_Enclosing)
 		{
-			if ((int)c.toAscii() >= 0)
+			if ((int)c.toLatin1() >= 0)
 				result.append(c);
 			else
 			{
-//				qDebug() << c << c.cell() << c.row() << c.unicode() << (int)c.toAscii() << (int)c.toLatin1() << c.decomposition().length();
+//				qDebug() << c << c.cell() << c.row() << c.unicode() << (int)c.toLatin1() << (int)c.toLatin1() << c.decomposition().length();
 				int pos = diacriticals.indexOf(c);
 				if (pos >= 0)
 				{

--- a/src/uploaders/imguranonuploader.cpp
+++ b/src/uploaders/imguranonuploader.cpp
@@ -50,7 +50,7 @@ QString ImgurAnonUploader::uploadImage(QString filePath, QIODevice *image)
 	tr.addHttpPart("image", filePath, image);
 	tr.addHttpPart("type", "file");
 	if (!albumId.isEmpty())
-		tr.addHttpPart("album_id", albumId.toAscii());
+		tr.addHttpPart("album_id", albumId.toLatin1());
 	tr.post();
 
 	ImgurResponse json(tr);
@@ -106,5 +106,5 @@ bool ImgurAnonUploader::checkCredits(int imageNumber, int extra)
 
 void ImgurAnonUploader::setAuthorization(NetworkTransaction *tr)
 {
-	tr->setRawHeader("Authorization", QString("Client-ID " IMGUR_CLIENT_ID).toAscii());
+	tr->setRawHeader("Authorization", QString("Client-ID " IMGUR_CLIENT_ID).toLatin1());
 }

--- a/src/uploaders/imgurloginuploader.cpp
+++ b/src/uploaders/imgurloginuploader.cpp
@@ -99,5 +99,5 @@ void ImgurLoginUploader::updateLoginInfo()
 
 void ImgurLoginUploader::setAuthorization(NetworkTransaction *tr)
 {
-	tr->setRawHeader("Authorization", QString("Bearer " + credentials.accessToken).toAscii());
+	tr->setRawHeader("Authorization", QString("Bearer " + credentials.accessToken).toLatin1());
 }

--- a/src/uploaders/iscodeuploader.cpp
+++ b/src/uploaders/iscodeuploader.cpp
@@ -23,7 +23,7 @@ IsCodeUploader::~IsCodeUploader()
 QString IsCodeUploader::uploadImage(QString filePath, QIODevice *image)
 {
 	NetworkTransactionMultiPart *tr = createTransaction(filePath, image);
-	tr->addHttpPart("cookie", ui->codeEdit->text().toAscii());
+	tr->addHttpPart("cookie", ui->codeEdit->text().toLatin1());
 	return postTransaction(tr, image);
 }
 

--- a/src/uploaders/isloginuploader.cpp
+++ b/src/uploaders/isloginuploader.cpp
@@ -31,8 +31,8 @@ QString IsLoginUploader::uploadImage(QString filePath, QIODevice *image)
 		return QString();
 
 	NetworkTransactionMultiPart *tr = createTransaction(filePath, image);
-	tr->addHttpPart("a_username", login.toAscii());
-	tr->addHttpPart("a_password", password.toAscii());
+	tr->addHttpPart("a_username", login.toLatin1());
+	tr->addHttpPart("a_password", password.toLatin1());
 	return postTransaction(tr, image);
 }
 

--- a/src/widgets/imagemanipulation.h
+++ b/src/widgets/imagemanipulation.h
@@ -63,7 +63,7 @@ private:
 	template<int operation(int, int)>
 	static void changeImage(QImage &im, int value)
 	{
-		if (im.numColors() == 0)
+		if (im.colorCount() == 0)
 		{
 			if (im.format() != QImage::Format_RGB32)
 				im = im.convertToFormat(QImage::Format_RGB32);
@@ -97,7 +97,7 @@ private:
 		else
 		{
 			QVector<QRgb> colors = im.colorTable();
-			for (int i = 0; i < im.numColors(); ++i)
+			for (int i = 0; i < im.colorCount(); ++i)
 				colors[i] = qRgb(operation(qRed(colors[i]), value),
 								 operation(qGreen(colors[i]), value),
 								 operation(qBlue(colors[i]), value));


### PR DESCRIPTION
- `QString::toAscii()` has been replaced 1:1 with `QString::toLatin1()`, which has a more adequate name.
- `QImage::numColors()` has been replaced 1:1 with `QImage::colorCount()`, maybe because it's name is more descriptive.