### PR TITLE
Enable obsolete classes and functions properly

### DIFF
--- a/fotorelacjonusz.pro
+++ b/fotorelacjonusz.pro
@@ -22,8 +22,8 @@ QT += core gui network websockets widgets xml xmlpatterns
 CONFIG += c++11
 
 # Fotorelacjonusz relies on some Qt4 APIs which are now deprecated, but still
-# available for legacy software.  This should be removed at some point.
-DEFINES += QT_DISABLE_DEPRECATED_BEFORE=4
+# available for legacy software.  This should be changed at some point.
+DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x000000
 
 # Make version number accessible in the application via PROGRAM_VERSION macro
 DEFINES += PROGRAM_VERSION=\\\"$$VERSION\\\"


### PR DESCRIPTION
Version number for `QT_DISABLE_DEPRECATED_BEFORE` is defined as a hexadecimal number.  See documentation for details: https://doc.qt.io/qt-5/qtglobal.html#QT_DISABLE_DEPRECATED_BEFORE.